### PR TITLE
Renamed ResultTypes

### DIFF
--- a/src/main/java/cora/analyzers/results/LoopingResult.java
+++ b/src/main/java/cora/analyzers/results/LoopingResult.java
@@ -20,7 +20,7 @@ public class LoopingResult implements Result {
   /** @return ResultType.YES */
   @Override
   public ResultType getResultType() {
-    return ResultType.YES;
+    return ResultType.NONTERMINATES;
   }
 
   /** @return a string containing the looping rules */

--- a/src/main/java/cora/analyzers/results/MatchesResult.java
+++ b/src/main/java/cora/analyzers/results/MatchesResult.java
@@ -22,7 +22,7 @@ public class MatchesResult implements Result {
    */
   @Override
   public ResultType getResultType() {
-    return ResultType.YES;
+    return ResultType.NONTERMINATES;
   }
 
   /**

--- a/src/main/java/cora/analyzers/results/SemiUnifyResult.java
+++ b/src/main/java/cora/analyzers/results/SemiUnifyResult.java
@@ -24,7 +24,7 @@ public class SemiUnifyResult implements Result {
    */
   @Override
   public ResultType getResultType() {
-    return ResultType.YES;
+    return ResultType.NONTERMINATES;
   }
 
   /**

--- a/src/main/java/cora/analyzers/results/UnifiesResult.java
+++ b/src/main/java/cora/analyzers/results/UnifiesResult.java
@@ -22,7 +22,7 @@ public class UnifiesResult implements Result {
    */
   @Override
   public Result.ResultType getResultType() {
-    return Result.ResultType.YES;
+    return Result.ResultType.NONTERMINATES;
   }
 
   /**

--- a/src/main/java/cora/interfaces/analyzers/Result.java
+++ b/src/main/java/cora/interfaces/analyzers/Result.java
@@ -5,7 +5,7 @@ package cora.interfaces.analyzers;
  */
 public interface Result {
   /** Possible result types for a result */
-  enum ResultType { NO, MAYBE, YES, TIMEOUT };
+  enum ResultType { MAYBE, NONTERMINATES, TIMEOUT };
 
   /** @return the result type of this result  */
   ResultType getResultType();

--- a/src/test/java/analyzers/DirectLoopAnalyzerTest.java
+++ b/src/test/java/analyzers/DirectLoopAnalyzerTest.java
@@ -127,6 +127,6 @@ public class DirectLoopAnalyzerTest {
   @Test
   public void testDirectLoopAnalyzerYesResult() throws AnalyzerInterruptedException {
     Result res = (new DirectLoopAnalyzer(createNonTerminatingTermRewritingSystem())).analyze(30);
-    assertEquals(Result.ResultType.YES, res.getResultType());
+    assertEquals(Result.ResultType.NONTERMINATES, res.getResultType());
   }
 }


### PR DESCRIPTION
Previously, we had `YES`, `NO`, `MAYBE` and `TIMEOUT`.  
So far, we have been using `YES` as a notion to say that the TRS does not terminate. This is rather unintuitive. This PR changes all the current occurrences of `YES` to `NO`. Then we changed all the occurrences of `NO` to `NONTERMINATES`. Finally, since we will not be using it in the non-termination analyzer, we deleted `YES`. 